### PR TITLE
Fixed README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Battle Game Server
+Battle Game Server
 =================
 
 Battle Game Server for CIS 219 Mobile III In-class lecture.  Has an API for use by other clients, especially Android clients, that will allow players to connect and play each other or alternatively play against  the "computer" which will be the server.
@@ -11,137 +11,180 @@ http://www.hasbro.com/commoninstruct/battleship.pdf
 
 ## API for Game Play between 2 clients  
 ## API Version 1  
-All API calls must be prefixed with /api/v1/XXX  
-![API Actions and Return Results](http://battlegameserver.com/api_graph.png)  
-[API Actions and Return Results](http://battlegameserver.com/api_graph.pdf)  
+All API calls must be prefixed with `/api/v1/XXX`
+![API Actions and Return Results](http://battlegameserver.com/api_graph.png)
+[API Actions and Return Results](http://battlegameserver.com/api_graph.pdf)
 
 ![Attack Sequence](http://battlegameserver.com/attack_sequence.png)  
 [Attack Sequence](http://battlegameserver.com/attack_sequence.pdf)  
 
 ## login  
-GET /api/v1/login.json  
-Uses basic authentication to login to the server  
+`GET /api/v1/login.json`
 
-### returns: Your user profile as a JSON object:  
-    {
-    id: 1,
-    first_name: "Dave",
-    last_name: "Jones",
-    avatar_name: "Dr.Dave",
-    level: 1,
-    coins: 0,
-    battles_won: 0,
-    battles_lost: 0,
-    battles_tied: 0,
-    experience_points: 0,
-    available: false,
-    online: false,
-    gaming: false,
-    email: "dave@lockersoft.com",
-    avatar_image: "avatars/davejones.jpg"
-    }
+Uses basic authentication to login to the server.
+
+Returns your user profile as a JSON object:
+```json
+{
+  "id": 1,
+  "first_name": "Dave",
+  "last_name": "Jones",
+  "avatar_name": "Dr.Dave",
+  "level": 1,
+  "coins": 0,
+  "battles_won": 0,
+  "battles_lost": 0,
+  "battles_tied": 0,
+  "experience_points": 0,
+  "available": false,
+  "online": false,
+  "gaming": false,
+  "email": "dave@lockersoft.com",
+  "avatar_image": "avatars/davejones.jpg"
+}
+```
 
 ## logout  
-GET /api/v1/logout.json  
-Logs the user out from the server  
+`GET /api/v1/logout.json`
 
-##available_players  
-GET /api/v1/available_users.json  
-  returns list of available players  
+Logs the user out from the server.
 
-##all_users  
-GET /api/v1/all_users.json  
-  returns list of ALL players whether they are available or not
+## available_players  
+`GET /api/v1/available_users.json`
 
-##available_ships  
-GET /api/v1/available_ships.json  
-###returns a list of all of the available ships names and their respective sizes.  
-    {
-    "carrier":5,
-    "battleship":4,
-    "cruiser":3,
-    "submarine":3,
-    "destroyer":2
-    }
+Returns list of available players.
 
-##available_directions  
-GET /api/v1/available_directions.json  
-###returns a list of all of the available directions for placing ships.  
-    {
-    "north":0,
-    "east":2,
-    "south":4,
-    "west":6
-    }
+## all_users  
+`GET /api/v1/all_users.json`
 
-##challenge_computer  
-GET api/v1/challenge_computer.json  
-###returns the game id which is used in future calls  
-    {
-    "game_id":7
-    }
+Returns list of ALL players whether they are available or not.
 
-##add_ship  
-GET api/v1/game/:id/add_ship/:ship/:row/:col/:direction.json  
-e.g.  /api/v1/game/7/add_ship/carrier/b/8/0.json  
-####Success:  
-    {"game_id":7,"status":"carrier ship added"}
+## available_ships  
+`GET /api/v1/available_ships.json`
 
-####ERROR:  
-    {"error":"illegal ship placement"}
+Returns a list of all of the available ships names and their respective sizes.
 
-##attack  
-send one attack sequence  
-GET api/v1/game/34/attack/h/3.json  
-####returns hit/miss in addition to the computer's turn  
-    {
-    "game_id":34,       
-    "row":h,          # Your Attack Row/Col
-    "col":3,
-    "hit":true,       # Did your attack hit a ship?
-    "comp_row":c,     # Computers Attack Row/Col
-    "comp_col":5,
-    "comp_hit":false  # Did the computer hit your ship?
-    "user_ship_sunk": "no",
-    "comp_ship_sunk": "cruiser",
-    "num_computer_ships_sunk": 3,
-    "num_your_ships_sunk": 2,
-    "winner": ""  #"computer", "you"
-    }
+```json
+{
+  "carrier": 5,
+  "battleship": 4,
+  "cruiser": 3,
+  "submarine": 3,
+  "destroyer": 2
+}
+```
 
-##status  
-Get the status of the boards and turns  
-GET api/v1/game/42/status/(type).json  
-all => return both boards
-defend => return defending board
-attack => return attacking board
-turn => NOT YET IMPLEMENTED
-####returns a string representing the board status with S for a ship, - for a Miss, * for a Hit.  
-    {
-    "game_id":42,
-    "attack_board":
-        "          \n          \n          \n          \n          \n          \n          \n          \n          \n          \n",
-    "defend_board":
-        "        S \n       S  \n  S  SS   \n  S  SS   \n  S SS S  \n     S    \n          \n          \n          \n  SSSS    \n"
-    }
-- - -  
+## available_directions  
+`GET /api/v1/available_directions.json`
 
-#All API's below are NOT YET IMPLEMENTED
+Returns a list of all of the available directions for placing ships.
 
-###challenge_player  
+```json
+{
+  "north": 0,
+  "east": 2,
+  "south": 4,
+  "west": 6
+}
+```
+
+## challenge_computer  
+`GET api/v1/challenge_computer.json`
+
+Returns the game id which is used in future calls.
+```json
+{
+  "game_id": 7
+}
+```
+
+## add_ship  
+`GET api/v1/game/:id/add_ship/:ship/:row/:col/:direction.json`
+
+e.g. `/api/v1/game/7/add_ship/carrier/b/8/0.json`
+
+#### Success:
+```json
+{
+  "game_id": 7,
+  "status": "carrier ship added"
+}
+```
+
+#### Error:
+```json
+{
+  "error": "illegal ship placement"
+}
+```
+
+## attack
+`GET api/v1/game/:id/attack/:row/:col.json`
+
+e.g. `GET api/v1/game/34/attack/h/3.json`
+
+Send one attack sequence.
+
+Returns hit/miss in addition to the computer's turn
+```json
+{
+  "game_id": 34,
+  "row": "h",          # Your Attack Row/Col
+  "col": 3,
+  "hit": true,         # Did your attack hit a ship?
+  "comp_row": "c",     # Computers Attack Row/Col
+  "comp_col": 5,
+  "comp_hit": false,   # Did the computer hit your ship?
+  "user_ship_sunk": "no",
+  "comp_ship_sunk": "cruiser",
+  "num_computer_ships_sunk": 3,
+  "num_your_ships_sunk": 2,
+  "winner": ""         #"computer", "you"
+}
+```
+
+## status   
+`GET api/v1/game/:id/status/:type.json`
+
+e.g. `GET api/v1/game/42/status/all.json`
+
+Get the status of the boards and turns.
+
+#### Valid `type`s:
+- `all` => return both boards
+- `defend` => return defending board
+- `attack` => return attacking board
+- `turn` => NOT YET IMPLEMENTED
+
+Returns a string representing the board status with `S` for a ship, `-` for a Miss, `*` for a Hit.
+```json
+{
+  "game_id":42,
+  "attack_board":
+      "          \n          \n          \n          \n          \n          \n          \n          \n          \n          \n",
+  "defend_board":
+      "        S \n       S  \n  S  SS   \n  S  SS   \n  S SS S  \n     S    \n          \n          \n          \n  SSSS    \n"
+}
+```
+
+---
+
+# All API's below are NOT YET IMPLEMENTED
+
+## challenge_player  
   returns acceptance?  
   
-###accept_challenge  
+## accept_challenge  
   returns acceptance?
   
-###setup_board  
+## setup_board  
   send initial board setup from client
       
-- - -  
+---
 
 ## Structures
 
-### User  
+### User
     first_name  
     last_name  
     avatar_name 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ http://www.hasbro.com/commoninstruct/battleship.pdf
 ## API for Game Play between 2 clients  
 ## API Version 1  
 All API calls must be prefixed with `/api/v1/XXX`
+
 ![API Actions and Return Results](http://battlegameserver.com/api_graph.png)
+
 [API Actions and Return Results](http://battlegameserver.com/api_graph.pdf)
 
-![Attack Sequence](http://battlegameserver.com/attack_sequence.png)  
+![Attack Sequence](http://battlegameserver.com/attack_sequence.png)
+
 [Attack Sequence](http://battlegameserver.com/attack_sequence.pdf)  
 
 ## login  
-`GET /api/v1/login.json`
+**GET `/api/v1/login.json`**
 
 Uses basic authentication to login to the server.
 
@@ -45,22 +48,22 @@ Returns your user profile as a JSON object:
 ```
 
 ## logout  
-`GET /api/v1/logout.json`
+**GET `/api/v1/logout.json`**
 
 Logs the user out from the server.
 
 ## available_players  
-`GET /api/v1/available_users.json`
+**GET `/api/v1/available_users.json`**
 
 Returns list of available players.
 
 ## all_users  
-`GET /api/v1/all_users.json`
+**GET `/api/v1/all_users.json`**
 
 Returns list of ALL players whether they are available or not.
 
 ## available_ships  
-`GET /api/v1/available_ships.json`
+**GET `/api/v1/available_ships.json`**
 
 Returns a list of all of the available ships names and their respective sizes.
 
@@ -75,7 +78,7 @@ Returns a list of all of the available ships names and their respective sizes.
 ```
 
 ## available_directions  
-`GET /api/v1/available_directions.json`
+**GET `/api/v1/available_directions.json`**
 
 Returns a list of all of the available directions for placing ships.
 
@@ -89,7 +92,7 @@ Returns a list of all of the available directions for placing ships.
 ```
 
 ## challenge_computer  
-`GET api/v1/challenge_computer.json`
+**GET `/api/v1/challenge_computer.json`**
 
 Returns the game id which is used in future calls.
 ```json
@@ -99,7 +102,7 @@ Returns the game id which is used in future calls.
 ```
 
 ## add_ship  
-`GET api/v1/game/:id/add_ship/:ship/:row/:col/:direction.json`
+**GET `/api/v1/game/:id/add_ship/:ship/:row/:col/:direction.json`**
 
 e.g. `/api/v1/game/7/add_ship/carrier/b/8/0.json`
 
@@ -119,7 +122,7 @@ e.g. `/api/v1/game/7/add_ship/carrier/b/8/0.json`
 ```
 
 ## attack
-`GET api/v1/game/:id/attack/:row/:col.json`
+**GET `/api/v1/game/:id/attack/:row/:col.json`**
 
 e.g. `GET api/v1/game/34/attack/h/3.json`
 
@@ -144,7 +147,7 @@ Returns hit/miss in addition to the computer's turn
 ```
 
 ## status   
-`GET api/v1/game/:id/status/:type.json`
+**GET `/api/v1/game/:id/status/:type.json`**
 
 e.g. `GET api/v1/game/42/status/all.json`
 

--- a/README.md
+++ b/README.md
@@ -126,20 +126,20 @@ e.g. `GET api/v1/game/34/attack/h/3.json`
 Send one attack sequence.
 
 Returns hit/miss in addition to the computer's turn
-```json
+```javascript
 {
   "game_id": 34,
-  "row": "h",          # Your Attack Row/Col
+  "row": "h",          // Your Attack Row/Col
   "col": 3,
-  "hit": true,         # Did your attack hit a ship?
-  "comp_row": "c",     # Computers Attack Row/Col
+  "hit": true,         // Did your attack hit a ship?
+  "comp_row": "c",     // Computers Attack Row/Col
   "comp_col": 5,
-  "comp_hit": false,   # Did the computer hit your ship?
+  "comp_hit": false,   // Did the computer hit your ship?
   "user_ship_sunk": "no",
   "comp_ship_sunk": "cruiser",
   "num_computer_ships_sunk": 3,
   "num_your_ships_sunk": 2,
-  "winner": ""         #"computer", "you"
+  "winner": ""         //"computer", "you"
 }
 ```
 


### PR DESCRIPTION
Fixed Markdown formatting and converted the examples to valid JSON. I was finding the page a bit hard to scan. It was mostly a matter of adding spaces between `##` and the rest of the header characters, but I decided to also add language tags to the JSON blocks so GitHub will enable syntax highlighting.

Here's a link to the README on my branch: https://github.com/schwingbat/battle_game_server/tree/patch-1